### PR TITLE
Fix video time for SearchYoutubeVideoAsync

### DIFF
--- a/src/YTSearch.NET.TestConsole/Program.cs
+++ b/src/YTSearch.NET.TestConsole/Program.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace YTSearch.NET.TestConsole
-{   
+{
     class TestConsole
     {
         static async Task Main(string[] args)
@@ -12,25 +13,41 @@ namespace YTSearch.NET.TestConsole
             var client = new YouTubeSearchClient();
 
             //var a = (await client.SearchYoutubeAsync("never gonna give you up")).Results.First().Url;
-            var result = (await client.GetVideoMetadataAsync(new Uri("https://www.youtube.com/watch?v=yXQViqx6GMY"))).Result;
+            var _metadata_test = (await client.GetVideoMetadataAsync(new Uri("https://www.youtube.com/watch?v=yXQViqx6GMY"))).Result;
 
             //Debugger.Break();
 
-            Console.WriteLine(result.Author); // MariahCareyVEVO
-            Console.WriteLine(result.Category); // Music
-            Console.WriteLine(result.IsCrawlable); // True
-            Console.WriteLine(result.IsFamilyFriendly); // True
-            Console.WriteLine(result.IsLiveContent); // False
-            Console.WriteLine(result.IsPrivate); // False
-            Console.WriteLine(result.IsRatingEnabled); // True
-            Console.WriteLine(result.IsUnlisted); // False
-            Console.WriteLine(result.Length); // 00:03:55
-            Console.WriteLine(result.PublishedDate); // 23/11/2009 12:00:00 am
-            Console.WriteLine(result.UploadedDate); // 23/11/2009 12:00:00 am
-            Console.WriteLine(result.Title); // Mariah Carey - All I Want For Christmas Is You (Official Video)
-            Console.WriteLine(result.Url); // https://www.youtube.com/watch?v=yXQViqx6GMY
-            Console.WriteLine(result.VideoId); // yXQViqx6GMY
-            Console.WriteLine(result.Views); // 731599447
+            Console.WriteLine(_metadata_test.Author);           // MariahCareyVEVO
+            Console.WriteLine(_metadata_test.Category);         // Music
+            Console.WriteLine(_metadata_test.IsCrawlable);      // True
+            Console.WriteLine(_metadata_test.IsFamilyFriendly); // True
+            Console.WriteLine(_metadata_test.IsLiveContent);    // False
+            Console.WriteLine(_metadata_test.IsPrivate);        // False
+            Console.WriteLine(_metadata_test.IsRatingEnabled);  // True
+            Console.WriteLine(_metadata_test.IsUnlisted);       // False
+            Console.WriteLine(_metadata_test.Length);           // 00:03:55
+            Console.WriteLine(_metadata_test.PublishedDate);    // 23/11/2009 12:00:00 am
+            Console.WriteLine(_metadata_test.UploadedDate);     // 23/11/2009 12:00:00 am
+            Console.WriteLine(_metadata_test.Title);            // Mariah Carey - All I Want For Christmas Is You (Official Video)
+            Console.WriteLine(_metadata_test.Url);              // https://www.youtube.com/watch?v=yXQViqx6GMY
+            Console.WriteLine(_metadata_test.VideoId);          // yXQViqx6GMY
+            Console.WriteLine(_metadata_test.Views);            // 731599447
+            Console.ReadKey();
+
+            // Should be the second song in the list, depends on Youtube tho and whats most popular
+            var _video_test = (await client.SearchYoutubeVideoAsync("Mariah Carey - All I Want For Christmas Is You (Official Video)")).Results;
+
+            foreach (SearchedYouTubeVideo _vid in _video_test)
+            {
+                Console.WriteLine(Environment.NewLine);
+                Console.WriteLine(_vid.Author);           // MariahCarey
+                Console.WriteLine(_vid.Length);           // 00:03:55
+                Console.WriteLine(_vid.Title);            // Mariah Carey - All I Want For Christmas Is You (Official Video)
+                Console.WriteLine(_vid.Url);              // https://www.youtube.com/watch?v=yXQViqx6GMY
+                Console.WriteLine(_vid.VideoId);          // yXQViqx6GMY
+                Console.WriteLine(_vid.Views);            // 731599447
+                Console.ReadKey();
+            }
         }
     }
 }

--- a/src/YTSearch.NET/YouTubeSearchClient.cs
+++ b/src/YTSearch.NET/YouTubeSearchClient.cs
@@ -139,28 +139,29 @@ namespace YTSearch.NET
 
         private TimeSpan ParseVideoLength(string? timespan)
         {
-            try
-            {
-                return TimeSpan.ParseExact(timespan, "hh\\:mm\\:ss", CultureInfo.InvariantCulture);
-            }
-            catch
-            {
+            TimeSpan output = TimeSpan.Zero;
+            if (timespan != null)
                 try
                 {
-                    return TimeSpan.ParseExact(timespan, "h\\:mm\\:ss", CultureInfo.InvariantCulture);
+                    switch (timespan.Split(':').Count())
+                    {
+                        case 1:
+                            output = TimeSpan.ParseExact(timespan, "%s", CultureInfo.InvariantCulture);
+                            break;
+                        case 2:
+                            output = TimeSpan.ParseExact(timespan, @"m\:ss", CultureInfo.InvariantCulture);
+                            break;
+                        default:
+                            output = TimeSpan.ParseExact(timespan, "g", CultureInfo.InvariantCulture);
+                            break;
+                    }
                 }
                 catch
                 {
-                    try
-                    {
-                        return TimeSpan.ParseExact(timespan, "mm\\:ss", CultureInfo.InvariantCulture);
-                    }
-                    catch
-                    {
-                        return TimeSpan.ParseExact(timespan, "m\\:ss", CultureInfo.InvariantCulture);
-                    }
+                    output = TimeSpan.Zero;
                 }
-            }
+
+            return output;
         }
     }
 }


### PR DESCRIPTION
Hey UnidentifiedX, saw your project on NuGet and have been using it for a bit. I wondered if your github repo had yt-music support and started tinkering with it and came across `SearchYoutubeVideoAsync` with its nested try catch statements. Had a lil play around with it and added a test for the `SearchYoutubeVideoAsync` along side the `GetVideoMetadataAsync` func in the `TestConsole`. 

Some results from `SearchYoutubeVideoAsync` report back 00:00:00, this is because they are live streams.